### PR TITLE
Mark all YAOB return types as `void` where appropriate

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -40,19 +40,19 @@ export class Bridge {
     )
   }
 
-  handleMessage(message: Message): mixed {
+  handleMessage(message: Message): void {
     this._state.handleMessage(message)
   }
 
-  getRoot() {
+  getRoot(): Promise<any> {
     return this._rootPromise
   }
 
-  sendRoot(root: Object) {
+  sendRoot(root: Object): void {
     this._state.emitEvent(0, 'root', root)
   }
 
-  close(error: Error) {
+  close(error: Error): void {
     this._state.close(error)
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ export interface BridgeOptions {
  */
 export declare class Bridge {
   constructor(opts: BridgeOptions)
-  handleMessage(message: object): unknown
+  handleMessage(message: object): void
   getRoot(): Promise<any>
   sendRoot(root: object): void
   close(error: Error): void
@@ -35,7 +35,7 @@ export declare function makeLocalBridge<T>(o: T, opts?: LocalBridgeOptions): T
 /**
  * Undoes the effect of `on` or `watch`.
  */
-export type CallbackRemover = () => unknown
+export type CallbackRemover = () => void
 
 /**
  * Signature of the `on` and `watch` methods.
@@ -73,6 +73,6 @@ export declare function bridgifyClass<Type extends Function>(Class: Type): Type
 export declare function bridgifyObject<Type extends object>(o: Type): Type
 export declare function shareData(table: object, namespace?: string): void
 
-export declare function close(o: object): unknown
-export declare function emit(o: object, name: string, payload: unknown): unknown
-export declare function update<T extends object>(o: T, name?: keyof T): unknown
+export declare function close(o: object): void
+export declare function emit(o: object, name: string, payload: unknown): void
+export declare function update<T extends object>(o: T, name?: keyof T): void

--- a/src/manage.js
+++ b/src/manage.js
@@ -9,7 +9,7 @@ import { getInstanceMagic } from './magic.js'
 /**
  * Undoes the effect of `on`.
  */
-export type CallbackRemover = () => mixed
+export type CallbackRemover = () => void
 
 /**
  * Signature of the `on` method.
@@ -68,7 +68,7 @@ export function addWatcher(
  * The remote client will completely forget about this object,
  * and accessing it will become an error.
  */
-export function close(o: Object): mixed {
+export function close(o: Object): void {
   const magic = getInstanceMagic(o)
 
   // Call local callbacks:
@@ -91,7 +91,7 @@ export function close(o: Object): mixed {
 /**
  * Emits an event on a bridgeable object.
  */
-export function emit(o: Object, name: string, payload: mixed): mixed {
+export function emit(o: Object, name: string, payload: mixed): void {
   const magic = getInstanceMagic(o)
   if (magic.closed) throw new Error('Cannot emit event on closed object')
 
@@ -112,7 +112,7 @@ export function emit(o: Object, name: string, payload: mixed): mixed {
 /**
  * Marks an object as having changes. The proxy server will send an update.
  */
-export function update<T: {}>(o: T, name?: $Keys<T>): mixed {
+export function update<T: {}>(o: T, name?: $Keys<T>): void {
   const magic = getInstanceMagic(o)
   if (magic.closed) throw new Error('Cannot update closed object')
 


### PR DESCRIPTION
This is not a breaking change, since it just makes the type definitions more accurate. We have to continue accepting `mixed` / `unknown` return types, though, since making those `void` would be a breaking change.